### PR TITLE
LinkedIn Ads ID: Enable LinkedIn Ads ID UserId module

### DIFF
--- a/modules/linkedInAdsIdSystem.js
+++ b/modules/linkedInAdsIdSystem.js
@@ -1,0 +1,124 @@
+/**
+ * This module adds LinkedIn Ads ID to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/linkedInAdsIdSystem
+ * @requires module:modules/userId
+ */
+
+import { logInfo, generateUUID } from '../src/utils.js';
+import { submodule } from '../src/hook.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
+import { uspDataHandler, coppaDataHandler, gdprDataHandler } from '../src/adapterManager.js';
+
+const MODULE_NAME = 'linkedInAdsId';
+const STORAGE_KEY = 'li_adsId';
+const LOG_PREFIX = 'LinkedIn Ads ID: ';
+const LI_FAT_COOKIE = 'li_fat';
+const LI_GIANT_COOKIE = 'li_giant';
+
+export const BrowserStorage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
+
+/** @type {Submodule} */
+export const linkedInAdsIdSubmodule = {
+
+  /**
+   * Used to link submodule with config
+   * @type {string}
+   */
+  name: MODULE_NAME,
+
+  /**
+   * @returns {Object} - Object with li_fat and li_giant as string properties
+   */
+  getCookieIds() {
+    return {
+      li_fat: BrowserStorage.getCookie(LI_FAT_COOKIE),
+      li_giant: BrowserStorage.getCookie(LI_GIANT_COOKIE),
+    };
+  },
+
+  /**
+   * Decode stored value for bid requests
+   * @param {string} id
+   * @returns {Object}
+   */
+  decode(id) {
+    const cookies = this.getCookieIds();
+    logInfo(`${LOG_PREFIX} found Legacy cookies: ${JSON.stringify(cookies)}`);
+
+    const linkedInAdsId = {
+      li_adsId: id,
+      ext: {
+        ...cookies,
+      },
+    };
+
+    return { linkedInAdsId };
+  },
+
+  /**
+   * Performs actions to obtain `linkedInAdsId` from storage
+   * @returns { { id: string } | undefined }
+   */
+  getId(config) {
+    const localKey = config?.storage?.name || STORAGE_KEY;
+    let id = BrowserStorage.localStorageIsEnabled() && BrowserStorage.getDataFromLocalStorage(localKey);
+
+    if (this.hasConsent() && !id) {
+      logInfo(`${LOG_PREFIX} existing id not found, generating a new li_adsId`);
+      id = generateUUID();
+    }
+
+    return { id };
+  },
+
+  /**
+   * Check all consent types, GDPR, CCPA, including processing TCF v2 consent string
+   * @returns {boolean}
+   */
+  hasConsent: function() {
+    /**
+     * GDPR check
+     * Negative of (consentData.gdprApplies === true || consentData.gdprApplies === 1)
+     */
+    const gdprConsentData = gdprDataHandler.getConsentData();
+    const hasGDPRConsent = !(gdprConsentData?.gdprApplies);
+
+    /**
+     * COPPA - Parental consent for the collection and use of personal data for users under the age of 13,
+     * as required by the COPPA regulation in the United States.
+     */
+    const isCoppaApplicable = coppaDataHandler.getCoppa();
+
+    /**
+     * CCPA Consent String processing
+     * https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md
+     */
+    const usPrivacyString = uspDataHandler.getConsentData();
+    const hasCCPAConsent = !(
+      usPrivacyString.length === 4 &&
+      usPrivacyString[1] === 'Y' && // Publisher has provided notice
+      usPrivacyString[2] === 'Y' // user has made a choice to opt out of sale
+    );
+
+    return hasGDPRConsent && hasCCPAConsent && !isCoppaApplicable;
+  },
+
+  eids: {
+    'linkedInAdsId': {
+      source: 'linkedin.com',
+      getValue: function(data) {
+        return data.li_adsId;
+      },
+      getUidExt: function(data) {
+        if (data.ext) {
+          return data.ext;
+        }
+      },
+      atype: 1,
+    },
+  }
+};
+
+submodule('userId', linkedInAdsIdSubmodule);

--- a/modules/linkedInAdsIdSystem.md
+++ b/modules/linkedInAdsIdSystem.md
@@ -1,0 +1,121 @@
+## LinkedIn Ads ID for Prebid
+
+#### Overview
+
+LinkedIn Ads ID is an addon for [Prebid User ID modules](https://docs.prebid.org/dev-docs/modules/userId.html), aimed at incorporating LinkedIn 1P advertising identifiers into Prebid controlled header-bidding. This module enables the capture and utilization of LinkedIn's Ads ID (`li_adsId`) for better targeting, serving, and efficiency in advertising campaigns.
+
+For support and queries, reachout to prebid-team@linkedin.com.
+
+#### Features
+
+- Integrates with Prebid User ID module to support LinkedIn Ads ID
+- Utilizes browser cookies to retrieve LinkedIn specific cookie-based 1P identifiers
+- Implements GDPR, CCPA, and COPPA consent checks to comply with privacy regulations
+- Supports the generation of a new LinkedIn Ads ID if an existing one is not found
+- Provides a mechanism to decode and prepare the LinkedIn Ads ID for bid requests
+
+#### Installation
+
+To install LinkedIn Ads ID, you must first ensure that Prebid User ID module is integrated into your Prebid setup. The [Prebid User ID module](https://github.com/prebid/Prebid.js/blob/master/modules/userId/index.js) is a prerequisite for enabling any User ID submodule.
+
+1. Clone or download the Prebid.js repository
+2. Navigate to the root directory of the cloned repository
+3. Include LinkedIn Ads ID in your build using the Prebid build tools.
+
+```
+gulp build –modules=linkedInAdsIdSystem,...
+```
+
+#### Usage
+
+To use LinkedIn Ads ID, follow these steps:
+
+1. Configure Prebid.js userIds section to include LinkedIn Ads ID by its submodule class name
+
+
+Example configuration:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: "linkedInAdsId",
+      storage: {
+        type: "html5",
+        name: "linkedInAdsId"
+      }
+    }],
+    auctionDelay: 50 // Optional: set auction delay in milliseconds
+  }
+});
+```
+
+Class Methods
+---
+
+#### `getCookieIds()`
+Returns the values of LinkedIn-specific cookies used for tracking (li_fat, li_giant) if set on page.
+
+#### `decode(id)`
+Decodes the stored LinkedIn Ads ID value for bid requests.
+
+#### `getId(config)`
+Retrieves the LinkedIn Ads ID from storage or generates a new one if necessary.
+
+#### `hasConsent()`
+Checks for the necessary consents (GDPR, CCPA, COPPA) before utilizing the LinkedIn Ads ID.
+
+Prebid methods
+---
+#### pbjs.getUserIds()
+```
+{
+  "linkedInAdsId": {
+    "li_adsId": "358cd91a-462d-4363-88ca-0e9a956c9c46",
+    "ext": {
+      "li_fat": <string>,
+      "li_giant": <string>
+    }
+  },
+  ...
+}
+```
+
+#### pbjs.getUserIdsAsEids()
+```
+[
+  {
+    "source": "linkedin.com",
+    "uids": [
+      {
+        "id": "358cd91a-462d-4363-88ca-0e9a956c9c46", // linkedInAdsId value
+        "atype": 1,
+        "ext": {
+          "li_fat": <string>,
+          "li_giant": <string>
+        }
+      }
+    ]
+  }, ...
+]
+```
+#### LocalStorage values example
+```
+{
+  "li_adsId_cst": "zix7LPQsHA==",
+  "li_adsId_exp": "Mon, 04 Mar 2024 20:30:05 GMT",
+  "li_adsId": "358cd91a-462d-4363-88ca-0e9a956c9c46"
+}
+```
+
+Consent Management
+---
+LinkedIn Ads ID checks for GDPR, CCPA, and COPPA consents to ensure compliance with privacy regulations. It uses the Prebid consent management modules (gdprDataHandler, uspDataHandler, coppaDataHandler) to verify that the necessary consents are in place.
+
+Contributing
+---
+Contributions to LinkedIn Ads ID are welcome. Please follow the contributing guidelines outlined in the Prebid.js repository when submitting issues or pull requests.
+
+License
+---
+LinkedIn Ads ID is licensed under the same license as the Prebid.js project. Please refer to the Prebid.js repository for more details on the license.

--- a/test/spec/modules/linkedInAdsIdSystem_spec.js
+++ b/test/spec/modules/linkedInAdsIdSystem_spec.js
@@ -1,0 +1,106 @@
+import {
+  linkedInAdsIdSubmodule,
+  BrowserStorage
+} from 'modules/linkedInAdsIdSystem.js';
+import * as Utils from '../../../src/utils.js';
+import { uspDataHandler, coppaDataHandler, gdprDataHandler } from 'src/adapterManager.js';
+
+describe('LinkedIn Ads ID module', () => {
+  const LI_FAT_COOKIE = 'li_fat';
+  const LI_GIANT_COOKIE = 'li_giant';
+  const dummyLiFat = '12345abc';
+  const dummyLiGiant = '67890xyz';
+
+  describe('getCookieIds', () => {
+    it('should return li_fat and li_giant cookies', () => {
+      const storageStub = sinon.stub(BrowserStorage, 'getCookie');
+
+      storageStub.withArgs(LI_FAT_COOKIE).returns(dummyLiFat);
+      storageStub.withArgs(LI_GIANT_COOKIE).returns(dummyLiGiant);
+
+      const cookies = linkedInAdsIdSubmodule.getCookieIds();
+
+      expect(cookies.li_fat).to.equal(dummyLiFat);
+      expect(cookies.li_giant).to.equal(dummyLiGiant);
+      storageStub.restore();
+    });
+  });
+
+  describe('decode', () => {
+    it('should return linkedInAdsId and legacy cookies if available', () => {
+      const storageStub = sinon.stub(BrowserStorage, 'getCookie');
+      storageStub.withArgs(LI_FAT_COOKIE).returns(dummyLiFat);
+      storageStub.withArgs(LI_GIANT_COOKIE).returns(dummyLiGiant);
+
+      const id = '12345abcde';
+      const decoded = linkedInAdsIdSubmodule.decode(id);
+
+      expect(decoded.linkedInAdsId).to.deep.equal({
+        li_adsId: id,
+        ext: {
+          li_fat: dummyLiFat,
+          li_giant: dummyLiGiant
+        }
+      });
+      storageStub.restore();
+    });
+  });
+
+  describe('getId', () => {
+    it('should generate and save a new ID', () => {
+      const genUuidStub = sinon.stub().returns('dummyId123');
+      Utils.generateUUID = genUuidStub;
+
+      const hasConsentStub = sinon.stub(linkedInAdsIdSubmodule, 'hasConsent');
+      hasConsentStub.returns(true);
+
+      const id = linkedInAdsIdSubmodule.getId();
+      expect(id).to.deep.equal({
+        id: 'dummyId123'
+      });
+
+      expect(genUuidStub.calledOnce).to.be.true;
+      hasConsentStub.restore();
+    });
+  });
+
+  describe('Consent checks `hasConsent`', () => {
+    let gdprStub, ccpaStub, coppaStub;
+
+    beforeEach(() => {
+      gdprStub = sinon.stub(gdprDataHandler, 'getConsentData');
+      ccpaStub = sinon.stub(uspDataHandler, 'getConsentData');
+      coppaStub = sinon.stub(coppaDataHandler, 'getCoppa');
+    });
+
+    afterEach(() => {
+      gdprStub.restore();
+      ccpaStub.restore();
+      coppaStub.restore();
+    });
+
+    it('should return false if GDPR consent missing', () => {
+      ccpaStub.returns('1YNN');
+      gdprStub.returns({gdprApplies: true});
+      expect(linkedInAdsIdSubmodule.hasConsent()).to.be.false;
+    });
+
+    it('should return false if CCPA opt-out', () => {
+      ccpaStub.returns('1YYN');
+      expect(linkedInAdsIdSubmodule.hasConsent()).to.be.false;
+    });
+
+    it('should return false if COPPA applicable', () => {
+      ccpaStub.returns('1YNN');
+      coppaStub.returns(true);
+      expect(linkedInAdsIdSubmodule.hasConsent()).to.be.false;
+    });
+
+    it('should return true if all consents present', () => {
+      gdprStub.returns({gdprApplies: false});
+      ccpaStub.returns('1YNN');
+      coppaStub.returns(false);
+      expect(linkedInAdsIdSubmodule.hasConsent()).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Enable LinkedIn Ads ID module – LinkedIn Ads ID is an addon for [Prebid User ID modules](https://docs.prebid.org/dev-docs/modules/userId.html), aimed at incorporating LinkedIn 1P advertising identifiers into Prebid controlled header-bidding. This module enables the capture and utilization of LinkedIn's Ads ID (li_adsId) for better targeting, serving, and efficiency in advertising campaigns.
