### PR TITLE
Harden PR assignment workflow against untrusted workflow_run artifacts

### DIFF
--- a/.github/workflows/PR-assignment-deps.yml
+++ b/.github/workflows/PR-assignment-deps.yml
@@ -6,6 +6,7 @@ permissions:
   contents: read
 jobs:
   generate_deps:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     name: Generate dependencies.json
     runs-on: ubuntu-latest
 

--- a/.github/workflows/PR-assignment.yml
+++ b/.github/workflows/PR-assignment.yml
@@ -7,7 +7,7 @@ on:
       - completed
 jobs:
   assign_reviewers:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository }}
     name: Assign reviewers
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- Restrict dependency artifact generation in `PR-assignment-deps.yml` to pull requests whose head repository matches the base repository.
- Add the same same-repository guard to `PR-assignment.yml` so privileged reviewer assignment does not process artifacts from fork-originated workflow runs.
- Preserve reviewer assignment behavior for trusted in-repo pull requests while blocking the artifact trust chain from external forks.

## Testing Done
- [x] Reviewed workflow logic and event fields used by the new guards.
- [x] Verified diff scope is limited to the two assignment workflows.
- [ ] CI run validation in upstream repository by maintainers.