### PR TITLE
Sanitize branch ref handling in test workflow shell steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,10 +44,12 @@ jobs:
 
       - name: Commit info
         id: info
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref }}
         run: |
           echo ref="${{ steps.checkout-pr.outputs.ref || steps.checkout-push.outputs.ref }}" >> $GITHUB_OUTPUT
           echo commit="${{ steps.checkout-pr.outputs.commit || steps.checkout-push.outputs.commit }}" >> $GITHUB_OUTPUT
-          echo branch="${{ github.head_ref || github.ref }}" >> $GITHUB_OUTPUT
+          printf 'branch=%s\n' "$HEAD_REF" >> "$GITHUB_OUTPUT"
           echo fork="${{ (github.event.pull_request && github.event.pull_request.head.repo.owner.login != github.repository_owner) && github.event.pull_request.head.repo.owner.login || null }}" >> $GITHUB_OUTPUT
           echo base-branch="${{ github.event.pull_request.base.ref || github.ref }}" >> $GITHUB_OUTPUT
           echo base-commit="${{ github.event.pull_request.base.sha || github.event.before }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Move branch reference capture in `test.yml` into an explicit `HEAD_REF` environment variable.
- Write the branch output using `printf` with quoting so branch names are handled as plain data.
- Keep existing checkout metadata behavior while removing shell interpolation risk from direct expression expansion.

## Testing Done
- [x] Reviewed generated shell script behavior for the updated step.
- [x] Verified change scope is limited to metadata output in `test.yml`.
- [ ] CI run validation in upstream repository by maintainers.