### PR TITLE
Escape changed file names in code-path notification emails

### DIFF
--- a/.github/workflows/code-path-changes.yml
+++ b/.github/workflows/code-path-changes.yml
@@ -31,8 +31,15 @@ jobs:
           node-version: '18'
 
       - name: Install dependencies
+        if: ${{ env.OAUTH2_CLIENT_ID != '' && env.OAUTH2_CLIENT_SECRET != '' && env.OAUTH2_REFRESH_TOKEN != '' }}
         run: npm install axios nodemailer
 
+      - name: Skip notification when mail secrets are missing
+        if: ${{ env.OAUTH2_CLIENT_ID == '' || env.OAUTH2_CLIENT_SECRET == '' || env.OAUTH2_REFRESH_TOKEN == '' }}
+        run: |
+          echo "Mail OAuth secrets are not configured. Skipping notification run."
+
       - name: Run Notification Script
+        if: ${{ env.OAUTH2_CLIENT_ID != '' && env.OAUTH2_CLIENT_SECRET != '' && env.OAUTH2_REFRESH_TOKEN != '' }}
         run: |
           node .github/workflows/scripts/send-notification-on-change.js

--- a/.github/workflows/code-path-changes.yml
+++ b/.github/workflows/code-path-changes.yml
@@ -16,6 +16,7 @@ env:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   notify:

--- a/.github/workflows/scripts/send-notification-on-change.js
+++ b/.github/workflows/scripts/send-notification-on-change.js
@@ -10,6 +10,15 @@ const path = require('path');
 const axios = require('axios');
 const nodemailer = require('nodemailer');
 
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 async function getAccessToken(clientId, clientSecret, refreshToken) {
   try {
     const response = await axios.post('https://oauth2.googleapis.com/token', {
@@ -109,12 +118,14 @@ async function getAccessToken(clientId, clientSecret, refreshToken) {
 
     // Send one email per recipient
     for (const [email, files] of Object.entries(matchesByEmail)) {
+      const safeFiles = files.map(file => `<li>${escapeHtml(file)}</li>`).join('');
+      const prUrl = `https://github.com/${owner}/${repoName}/pull/${encodeURIComponent(prNumber)}`;
       const emailBody = `
-        ${email},
+        ${escapeHtml(email)},
         <p>
-        Files relevant to your integration have been changed in open source ${repo}. The <a href="https://github.com/${repo}/pull/${prNumber}">pull request is #${prNumber}</a>. These are the files you monitor that have been modified:
+        Files relevant to your integration have been changed in open source ${escapeHtml(repo)}. The <a href="${prUrl}">pull request is #${escapeHtml(prNumber)}</a>. These are the files you monitor that have been modified:
         <ul>
-          ${files.map(file => `<li>${file}</li>`).join('')}
+          ${safeFiles}
         </ul>
       `;
 
@@ -127,7 +138,6 @@ async function getAccessToken(clientId, clientSecret, refreshToken) {
         });
 
         console.log(`Email sent successfully to ${email}`);
-        console.log(`${emailBody}`);
       } catch (error) {
         console.error(`Failed to send email to ${email}:`, error.message);
       }

--- a/.github/workflows/scripts/send-notification-on-change.js
+++ b/.github/workflows/scripts/send-notification-on-change.js
@@ -46,9 +46,14 @@ async function getAccessToken(clientId, clientSecret, refreshToken) {
   const refreshToken = process.env.OAUTH2_REFRESH_TOKEN;
 
   // validate params
-  if (!repo || !prNumber || !token || !clientId || !clientSecret || !refreshToken) {
+  if (!repo || !prNumber || !token) {
     console.error('Missing required environment variables.');
     process.exit(1);
+  }
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    console.log('Mail OAuth secrets are not configured. Skipping notifications.');
+    process.exit(0);
   }
 
   // the whole process is in a big try/catch. e.g. if the config file doesn't exist, github is down, etc.


### PR DESCRIPTION
## Summary
- Escape changed file names before inserting them into HTML email content in `send-notification-on-change.js`.
- Escape other interpolated values in the generated email body and stop logging raw HTML payloads.
- Add explicit `pull-requests: read` permission in `code-path-changes.yml` for least-privilege API access clarity.
- Skip notification execution when mail OAuth secrets are not configured so the workflow exits cleanly instead of failing all PRs.

## Testing Done
- [x] Reviewed escaping paths for all interpolated HTML fields.
- [x] Verified secret-missing path exits successfully in script and workflow gating.
- [ ] CI run validation in upstream repository by maintainers.